### PR TITLE
Remove using /usr/bin/env in scripts preambles

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,8 +6,8 @@
 CLOC = cloc --autoconf
 
 bin_SCRIPTS = pstops psbook psjoin psresize psselect psnup epsffit extractres includeres
-perldir = $(datadir)/perl
-perl_DATA = PSUtils.pm
+
+installvendorarch_DATA = PSUtils.pm
 
 man_MANS = psutils.1 \
 	psbook.1 psselect.1 pstops.1 epsffit.1 psnup.1 psresize.1 \

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ CLOC = cloc --autoconf
 
 bin_SCRIPTS = pstops psbook psjoin psresize psselect psnup epsffit extractres includeres
 
-installvendorarch_DATA = PSUtils.pm
+perl_installvendorlib_DATA = PSUtils.pm
 
 man_MANS = psutils.1 \
 	psbook.1 psselect.1 pstops.1 epsffit.1 psnup.1 psresize.1 \

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign 1.11])
 
 AC_PATH_PROG(PERL, perl)
-installvendorarchdir="$(eval $(${PERL} -V:installvendorarch); echo $installvendorarch)"
+perl_installvendorlibdir="$(eval $(${PERL} -V:installvendorlib); echo $installvendorlib)"
 AC_SUBST(installvendorarchdir)
 
 # Generate output files

--- a/configure.ac
+++ b/configure.ac
@@ -5,15 +5,21 @@ AC_INIT(psutils, 1.90, rrt@sc3d.org)
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign 1.11])
 
+AC_PATH_PROG(PERL, perl)
+
 # Generate output files
-AC_CONFIG_FILES([Makefile])
-AC_CONFIG_FILES([pstops], [chmod +x pstops])
-AC_CONFIG_FILES([psbook], [chmod +x psbook])
-AC_CONFIG_FILES([psjoin], [chmod +x psjoin])
-AC_CONFIG_FILES([psresize], [chmod +x psresize])
-AC_CONFIG_FILES([psselect], [chmod +x psselect])
-AC_CONFIG_FILES([psnup], [chmod +x psnup])
-AC_CONFIG_FILES([epsffit], [chmod +x epsffit])
-AC_CONFIG_FILES([extractres], [chmod +x extractres])
-AC_CONFIG_FILES([includeres], [chmod +x includeres])
-AC_OUTPUT
+AC_OUTPUT([
+	Makefile
+	epsffit
+	extractres
+	includeres
+	psbook
+	psjoin
+	psnup
+	psresize
+	psselect
+	pstops
+	],
+	[chmod +x epsffit extractres includeres psbook psjoin psnup psresize
+	    psselect pstops]
+)

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,8 @@ AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign 1.11])
 
 AC_PATH_PROG(PERL, perl)
+installvendorarchdir="$(eval $(${PERL} -V:installvendorarch); echo $installvendorarch)"
+AC_SUBST(installvendorarchdir)
 
 # Generate output files
 AC_OUTPUT([

--- a/epsffit.in
+++ b/epsffit.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!@PERL@
 my $version_banner = <<END;
 epsffit @VERSION@
 Copyright (c) Reuben Thomas 2016

--- a/extractres.in
+++ b/extractres.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!@PERL@
 my $version_banner = <<END;
 extractres @VERSION@
 Copyright (c) Reuben Thomas 2012-2019

--- a/includeres.in
+++ b/includeres.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!@PERL@
 my $version_banner = <<END;
 includeres @VERSION@
 Copyright (c) Reuben Thomas 2012-2019

--- a/psbook.in
+++ b/psbook.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!@PERL@
 my $version_banner = <<END;
 psbook @VERSION@
 Copyright (c) Reuben Thomas 2016

--- a/psjoin.in
+++ b/psjoin.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!@PERL@
 my $version_banner = <<END;
 psjoin @VERSION@
 Copyright (c) Tom Sato 2002-2003

--- a/psnup.in
+++ b/psnup.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!@PERL@
 # @configure_input@
 my $version_banner = <<END;
 psnup @VERSION@

--- a/psresize.in
+++ b/psresize.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!@PERL@
 my $version_banner = <<END;
 psresize @VERSION@
 Copyright (c) Reuben Thomas 2016

--- a/psselect.in
+++ b/psselect.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!@PERL@
 my $version_banner = <<END;
 psselect @VERSION@
 Copyright (c) Reuben Thomas 2016

--- a/pstops.in
+++ b/pstops.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!@PERL@
 my $version_banner = <<END;
 pstops @VERSION@
 Copyright (c) Reuben Thomas 2017-2019


### PR DESCRIPTION
Replace use /usr/bin/env in scripts preambles and detect where is actual perl + small simplification in autoconf.