### PR TITLE
Fix urls in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     {name = "Reuben Thomas", email = "rrt@sc3d.org"}
 ]
 readme = "README.md"
-urls = {home_page = "https://github.com/rrthomas/psutils"}
+urls = {Homepage = "https://github.com/rrthomas/psutils"}
 requires-python = ">= 3.9"
 dependencies = [
     "puremagic",


### PR DESCRIPTION
Use commonly used key for `Homepage`. This fixes homepage display on PyPI and makes external tools correctly recognize url type.