### PR TITLE
Fixed crash for international number formats

### DIFF
--- a/psutils/libpaper.py
+++ b/psutils/libpaper.py
@@ -34,7 +34,7 @@ def get_paper_size(paper_name: Optional[str] = None) -> Optional[Rectangle]:
         dimensions = paper(["--unit=pt", paper_name], True)
     if dimensions is None:
         return None
-    m = re.search(" ([.0-9]+)x([.0-9]+) pt$", dimensions)
+    m = re.search(" ([.,0-9]+)x([.,0-9]+) pt$", dimensions)
     assert m
-    w, h = float(m[1]), float(m[2])
+    w, h = float(m[1].replace(",", ".")), float(m[2].replace(",", "."))
     return Rectangle(round(w), round(h))  # round dimensions to nearest point


### PR DESCRIPTION
`libpaper` returns paper sizes in localized formats and thus sometimes the dimensions will use a comma (`,`) instead of a decimal point (`.`). e.g. `A4: 595,276x841,89 pt`

This fixes the parsing of `libpapers` output to accept both number formats.