### PR TITLE
Add support for - for INFILE and OUTFILE

### DIFF
--- a/psutils/command/pstops.py
+++ b/psutils/command/pstops.py
@@ -108,9 +108,9 @@ def pstops(argv: list[str] = sys.argv[1:]) -> None:
     # Get specs if we don't have them yet
     if args.specs is None:
         if args.infile is None:
-            parser.print_help()
-            sys.exit(1)
-        args.specs = args.infile
+            args.specs = '-'
+        else:
+            args.specs = args.infile
         try:
             parsespecs(args.specs, paper_context, err_function=spec_exception)
             args.infile = args.outfile

--- a/psutils/io.py
+++ b/psutils/io.py
@@ -22,13 +22,13 @@ def setup_input_and_output(
 ) -> Iterator[tuple[IO[bytes], str, IO[bytes]]]:
     # Set up input
     infile: IO[bytes] | None = None
-    if infile_name is not None:
+    if infile_name is None or infile_name == '-':
+        infile = os.fdopen(sys.stdin.fileno(), "rb", closefd=False)
+    else:
         try:
             infile = open(infile_name, "rb")
         except OSError:
             die(f"cannot open input file {infile_name}")
-    else:
-        infile = os.fdopen(sys.stdin.fileno(), "rb", closefd=False)
 
     # Find MIME type of input
     data = infile.read(16)
@@ -39,13 +39,13 @@ def setup_input_and_output(
     infile.close()
 
     # Set up output
-    if outfile_name is not None:
+    if outfile_name is None or outfile_name == '-':
+        outfile = os.fdopen(sys.stdout.fileno(), "wb", closefd=False)
+    else:
         try:
             outfile = open(outfile_name, "wb")
         except OSError:
             die(f"cannot open output file {outfile_name}")
-    else:
-        outfile = os.fdopen(sys.stdout.fileno(), "wb", closefd=False)
 
     # Context manager
     try:


### PR DESCRIPTION
Hi,

I started using psutils for PDF manipulation yesterday and it’s great. Thanks to the nup feature, it allows me to avoid using pdfjam, which requires a behemoth of a texlive install.

However, once I started piping `psbook` output into `psnup`, as one does, I noticed some weird behaviour. It turns out that, at least in my Alpine Docker container, `-` does not work as `STDIN` for an input file, or as `STDOUT` for the output file. Not specifying a file works, but I was using `STDIN` for the input and a file as the output to `psnup`, and for that you need the `-` for the first argument (or no arguments, and use a redirect for the output file, but when I realised that, I had already started reading the code.)

So I wrote a “test suite” where I try every combination of a regular file, `-`, and no file for both the input and the output (except “no input file and a regular output file” and “no input file and `-` as the output file”, which cannot be achieved,) for every command, and I managed to find a fix for all of them except `psjoin`, because it works differently and I couldn’t really figure out how to do it properly.

I’m including the test suite: [tests.zip](https://github.com/user-attachments/files/22046761/tests.zip). You should be able to run `./test.bash`, and with my fixes, it should succeed for everything except `psjoin`.

As you can see, there’s not much to the fix: handling the case of `-` the same way as `None` in `setup_input_and_output ` does the trick. It just needs an extra step in `pstops`, because it exits early if no input file is given.

Let me know what you think, I’m available if you have questions or remarks.