### PR TITLE
Fix tests on Python 3.14. 

### DIFF
--- a/psutils/transformers.py
+++ b/psutils/transformers.py
@@ -515,8 +515,8 @@ def document_transform(
 
 @contextmanager
 def file_transform(
-    infile_name: str,
-    outfile_name: str,
+    infile_name: str | None,
+    outfile_name: str | None,
     size: Rectangle | None,
     in_size: Rectangle | None,
     specs: list[list[PageSpec]],

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -144,7 +144,7 @@ def file_test(
     with chdir(datafiles):
         correct_output = True
         if case.error is None:
-            with patch("sys.argv", patched_argv):
+            with patch("sys.argv", patched_argv), patch.object(sys.modules['__main__'], '__spec__', None):
                 function(full_args)
             if regenerate_expected:
                 shutil.copyfile(output_file, expected_file.with_suffix(file_type))
@@ -160,7 +160,7 @@ def file_test(
                 )
         else:
             with pytest.raises(SystemExit) as e:
-                with patch("sys.argv", patched_argv):
+                with patch("sys.argv", patched_argv), patch.object(sys.modules['__main__'], '__spec__', None):
                     function(full_args)
             assert e.value.code == case.error
         if regenerate_expected:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py312,py313
+envlist = py312,py313,py314
 
 [testenv]
 deps =


### PR DESCRIPTION
Pyright complained on every python version, handled that to make tox happy with every interpreter.